### PR TITLE
Fix strategy buttons

### DIFF
--- a/handlers/strategy.py
+++ b/handlers/strategy.py
@@ -28,8 +28,9 @@ STRATEGIES = {
 
 @rate_limit()
 async def strategy(update: Update, context: ContextTypes.DEFAULT_TYPE, cancel: bool = False):
+    message = update.effective_message
     if cancel:
-        await update.message.reply_text("❌ Настройка стратегии отменена")
+        await message.reply_text("❌ Настройка стратегии отменена")
         return ConversationHandler.END
         
     await log_action("strategy_command", "User requested strategy selection", update.effective_user.id)
@@ -42,7 +43,7 @@ async def strategy(update: Update, context: ContextTypes.DEFAULT_TYPE, cancel: b
     ]
     reply_markup = InlineKeyboardMarkup(keyboard)
     
-    await update.message.reply_text(
+    await message.reply_text(
         "📊 Выберите торговую стратегию:",
         reply_markup=reply_markup
     )
@@ -98,7 +99,7 @@ async def strategy_configuration(update: Update, context: ContextTypes.DEFAULT_T
         
         # Форматируем подтверждение
         formatted_params = format_strategy_params(params)
-        await update.message.reply_text(
+        await update.effective_message.reply_text(
             f"✅ Стратегия {strategy_info['name']} настроена:\n\n"
             f"{formatted_params}\n\n"
             f"Используйте /backtest для тестирования"
@@ -114,7 +115,7 @@ async def strategy_configuration(update: Update, context: ContextTypes.DEFAULT_T
         
     except Exception as e:
         logger.error(f"Strategy config error: {e}")
-        await update.message.reply_text(
+        await update.effective_message.reply_text(
             "❌ Ошибка в формате параметров. Попробуйте еще раз или введите /cancel"
         )
         return CONFIGURE_STRATEGY

--- a/main.py
+++ b/main.py
@@ -79,7 +79,10 @@ application.add_handler(candles_conv_handler)
 
 # FSM для стратегий
 conv_handler = ConversationHandler(
-    entry_points=[CommandHandler('strategy', strategy)],
+    entry_points=[
+        CommandHandler('strategy', strategy),
+        CallbackQueryHandler(strategy, pattern='^strategy$'),
+    ],
     states={
         SELECT_STRATEGY: [
             CallbackQueryHandler(strategy_selection, pattern='^(MA|RSI|Bollinger)$')
@@ -122,9 +125,6 @@ async def button_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
             text = format_portfolio(portfolio_data)
             await query.edit_message_text(text)
             
-        elif query.data == "strategy":
-            await strategy(update, context)
-            
         elif query.data == "backtest":
             await backtest(update, context)
             
@@ -144,9 +144,6 @@ async def button_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
             
         elif query.data == "refresh_portfolio":
             await portfolio(update, context)
-            
-        elif query.data == "launch_strategy":
-            await strategy(update, context)
             
         elif query.data == "show_forest":
             await query.edit_message_text("🌲 Ваш лес: 1 дерево! (геймификация)")


### PR DESCRIPTION
## Summary
- fix `strategy()` handler to work for callback queries
- start strategy conversation from inline keyboard
- cleanup strategy-related button handler logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_6875f5db285c8325b5e1cbd183c64670